### PR TITLE
fix: 修复broker集群宕机情况下，客户端刷新连接时，若各连接抛出异常时机不一致，则仍未抛出异常的连接uri无法加入unHealth…

### DIFF
--- a/alibaba-rsocket-core/src/main/java/com/alibaba/rsocket/loadbalance/LoadBalancedRSocket.java
+++ b/alibaba-rsocket-core/src/main/java/com/alibaba/rsocket/loadbalance/LoadBalancedRSocket.java
@@ -138,10 +138,11 @@ public class LoadBalancedRSocket extends AbstractRSocket implements CloudEventRS
                         return connect(rsocketUri)
                                 //health check after connection
                                 .flatMap(rsocket -> healthCheck(rsocket, rsocketUri).map(payload -> Tuples.of(rsocketUri, rsocket)))
-                                .doOnError(error -> {
+                                .onErrorResume(error -> {
                                     log.error(RsocketErrorCode.message("RST-400500", rsocketUri), error);
                                     this.unHealthyUriSet.add(rsocketUri);
                                     tryToReconnect(rsocketUri, error);
+                                    return Mono.empty();
                                 });
                     }
                 })

--- a/alibaba-rsocket-core/src/main/java/com/alibaba/rsocket/upstream/UpstreamManagerImpl.java
+++ b/alibaba-rsocket-core/src/main/java/com/alibaba/rsocket/upstream/UpstreamManagerImpl.java
@@ -146,9 +146,9 @@ public class UpstreamManagerImpl implements UpstreamManager {
             if (!brokerCluster.isLocal()) {
                 //interval sync to broker to get last broker list in case of UpstreamClusterChangedEvent lost
                 Flux.interval(Duration.ofSeconds(120))
-                        .flatMap(timestamp -> findBrokerDiscoveryService().getInstances("*"))
-                        .map(serviceInstances -> serviceInstances.stream().map(RSocketServiceInstance::getUri).collect(Collectors.toList()))
-                        .subscribe(uris -> brokerCluster.setUris(uris));
+                    .subscribe(timestamp -> findBrokerDiscoveryService().getInstances("*")
+                                                                        .map(serviceInstances -> serviceInstances.stream().map(RSocketServiceInstance::getUri).collect(Collectors.toList()))
+                                                                        .subscribe(uris -> brokerCluster.setUris(uris)));
             }
             if (p2pServices != null && !p2pServices.isEmpty()) {
                 // interval sync to p2p service instances list


### PR DESCRIPTION
版本：
1.1.5

部署情况：
三节点的Gossip广播模式集群部署。

缺陷现象描述：
broker三节点关停一段时间后启动，存在部分客户端无法全部自动注册上三个broker节点。

异常类：
com.alibaba.rsocket.loadbalance.LoadBalancedRSocket

问题原因：
在所有节点关停后，客户端中维持的最后一条活跃连接触发onRSocketClosed，并将原始三节点uri进行refreshRsockets。这三条链接在connect或healthcheck阶段中会抛出连接相关异常，进而触发后续的异常处理流程；
但在此链接的异常处理流程执行完成前，若其余连接仍未抛出异常执行对应异常处理流程，则会被异常撤销流程，以至于无法加入unHealthyUriSet。故checkUnhealthyUris方法无法重连此异常链接。
![1720589728359](https://github.com/reactive-rsocket-broker/rsocket-broker/assets/50613743/b73684a8-78df-4d9f-a5c7-c066afcb3a3e)

处理思路：
在refreshRsockets方法中对connect及healthcheck阶段的异常进行捕获并不再抛出，返回空流。
![1720590425614](https://github.com/reactive-rsocket-broker/rsocket-broker/assets/50613743/b1d0ee18-c616-4294-8e1d-dcc8c66a4e89)